### PR TITLE
Fixing issue where pages were being keyed by wrong query

### DIFF
--- a/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -155,7 +155,7 @@ public class GraphQLQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: Graph
           } else {
             shouldUpdate = true
           }
-          let variables = initialQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? []
+          let variables = nextPageQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? []
           if shouldUpdate {
             self.pageOrder.append(variables)
           }


### PR DESCRIPTION
each page should be keyed by the query that generated that page, not by the initial query.